### PR TITLE
Removing unnecessary exported methods for parsing policies

### DIFF
--- a/cpa/parsing.go
+++ b/cpa/parsing.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/CircleCI-Public/circle-policy-agent/internal/helpers"
 	"github.com/open-policy-agent/opa/ast"
+
+	"github.com/CircleCI-Public/circle-policy-agent/internal/helpers"
 )
 
 // This function has been stolen from the OPA codebase, ast/parser.go:2210 for
@@ -57,11 +58,6 @@ func AllowedPackages(names ...string) LintRule {
 	}
 }
 
-// ParseRego will parse a rego document, validating it, and compiling it.
-func ParseRego(filename, rego string, rules ...LintRule) (*Policy, error) {
-	return ParseBundle(map[string]string{filename: rego}, rules...)
-}
-
 func shouldImportConfigHelpers(mods map[string]*ast.Module) bool {
 	for _, m := range mods {
 		for _, i := range m.Imports {
@@ -73,8 +69,8 @@ func shouldImportConfigHelpers(mods map[string]*ast.Module) bool {
 	return false
 }
 
-// ParseBundle will parse multiple rego files together into a bundle
-func ParseBundle(bundle map[string]string, rules ...LintRule) (*Policy, error) {
+// parseBundle will parse multiple rego files together into a bundle
+func parseBundle(bundle map[string]string, rules ...LintRule) (*Policy, error) {
 	moduleMap := make(map[string]*ast.Module, len(bundle))
 
 	var multiErr MultiError
@@ -120,10 +116,10 @@ func ParseBundle(bundle map[string]string, rules ...LintRule) (*Policy, error) {
 }
 
 //nolint:lll
-// ParsePolicy will restrict package name to 'org'. This allows us to more easily extract information from the OPA output after evaluating a
+// ParseBundle will restrict package name to 'org'. This allows us to more easily extract information from the OPA output after evaluating a
 // policy, because we know what the keys will be in the map that contains the results (e.g., map["org"]["enable_rule"] to find enabled rules).
-func ParsePolicy(files map[string]string) (*Policy, error) {
-	return ParseBundle(files, AllowedPackages("org"))
+func ParseBundle(files map[string]string) (*Policy, error) {
+	return parseBundle(files, AllowedPackages("org"))
 }
 
 type MultiError []error

--- a/cpa/parsing_test.go
+++ b/cpa/parsing_test.go
@@ -60,7 +60,7 @@ func TestRegoParsing(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			_, err := ParseRego("test.rego", tc.Document, tc.LintRules...)
+			_, err := parseBundle(map[string]string{"test.rego": tc.Document}, tc.LintRules...)
 
 			if tc.Error == nil && err != nil {
 				t.Fatalf("expected no error but got: %v", err)

--- a/cpa/policy_decide_test.go
+++ b/cpa/policy_decide_test.go
@@ -492,7 +492,7 @@ func TestDecide(t *testing.T) {
 						t.Fatalf("invalid config: %v", err)
 					}
 
-					doc, err := ParseRego("test.rego", tc.Document)
+					doc, err := parseBundle(map[string]string{"test.rego": tc.Document})
 					if err != nil {
 						t.Fatalf("failed to parse rego document for testing: %v", err)
 					}

--- a/cpa/policy_test.go
+++ b/cpa/policy_test.go
@@ -50,7 +50,7 @@ func TestParsePolicy(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			_, err := ParsePolicy(tc.DocumentBundle)
+			_, err := ParseBundle(tc.DocumentBundle)
 
 			if tc.Error == nil && err != nil {
 				t.Fatalf("expected no error but got: %v", err)
@@ -93,7 +93,7 @@ func TestDocumentQuery(t *testing.T) {
 		},
 	}
 
-	doc, err := ParseRego("test.rego", `
+	doc, err := parseBundle(map[string]string{"test.rego": `
 		package test
 		import future.keywords
 
@@ -110,7 +110,7 @@ func TestDocumentQuery(t *testing.T) {
 			some name in names;
 			not product[name]
 		}
-	`)
+	`})
 
 	if err != nil {
 		t.Fatalf("failed to parse rego document for testing: %v", err)
@@ -157,7 +157,7 @@ func TestBundleQuery(t *testing.T) {
 		},
 	}
 
-	doc, err := ParseBundle(map[string]string{
+	doc, err := parseBundle(map[string]string{
 		"helper.rego": `
 			package helper
 			names[name] {


### PR DESCRIPTION
## Rationale
We  were exporting too many similar looking public methods for parsing policies.
Now only exporting just one.

## Considerations
NA

## Changes

- Removed ParseRego
- Unexported ParseBundle
- Renamed ParsePolicy to ParseBundle
- Updated tests
