### PR TITLE
[SECENG-582] Add methods for loading policies from filesystem

### DIFF
--- a/cpa/parsing.go
+++ b/cpa/parsing.go
@@ -142,9 +142,10 @@ func (err MultiError) Error() string {
 	}
 }
 
+//LoadPolicyFile takes policy file path as an input, and returns parsed policy
 func LoadPolicyFile(filePath string) (*Policy, error) {
 	documentBundle := map[string]string{}
-	fileContent, err := ioutil.ReadFile(filePath)
+	fileContent, err := ioutil.ReadFile(filepath.Clean(filePath))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}
@@ -152,21 +153,20 @@ func LoadPolicyFile(filePath string) (*Policy, error) {
 	return ParseBundle(documentBundle)
 }
 
+//LoadPolicyDirectory takes path of directory containing policies as an input, and returns parsed policy
+//every file in the top-level of the directory (non-recursive) will be considered as a policy file for parsing
 func LoadPolicyDirectory(directoryPath string) (*Policy, error) {
 	documentBundle := map[string]string{}
 	policyFiles, err := ioutil.ReadDir(directoryPath) //get list of all files in given directory path
 	if err != nil {
 		return nil, fmt.Errorf("failed to get list of policy files: %w", err)
 	}
-	if len(policyFiles) == 0 {
-		return nil, fmt.Errorf("no files found in: %s", directoryPath)
-	}
 	for _, f := range policyFiles {
 		if f.IsDir() {
 			continue
 		}
 		filePath := filepath.Join(directoryPath, f.Name()) //get absolute file path
-		fileContent, err := ioutil.ReadFile(filePath)
+		fileContent, err := ioutil.ReadFile(filepath.Clean(filePath))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read file: %w", err)
 		}

--- a/cpa/parsing.go
+++ b/cpa/parsing.go
@@ -2,7 +2,7 @@ package cpa
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -144,8 +144,8 @@ func (err MultiError) Error() string {
 
 //LoadPolicyFile takes policy file path as an input, and returns parsed policy
 func LoadPolicyFile(filePath string) (*Policy, error) {
-	documentBundle := map[string]string{}
-	fileContent, err := ioutil.ReadFile(filepath.Clean(filePath))
+	documentBundle := make(map[string]string, 1)
+	fileContent, err := os.ReadFile(filepath.Clean(filePath))
 	if err != nil {
 		return nil, fmt.Errorf("failed to read file: %w", err)
 	}
@@ -156,17 +156,17 @@ func LoadPolicyFile(filePath string) (*Policy, error) {
 //LoadPolicyDirectory takes path of directory containing policies as an input, and returns parsed policy
 //every file in the top-level of the directory (non-recursive) will be considered as a policy file for parsing
 func LoadPolicyDirectory(directoryPath string) (*Policy, error) {
-	documentBundle := map[string]string{}
-	policyFiles, err := ioutil.ReadDir(directoryPath) //get list of all files in given directory path
+	policyFiles, err := os.ReadDir(directoryPath) //get list of all files in given directory path
 	if err != nil {
 		return nil, fmt.Errorf("failed to get list of policy files: %w", err)
 	}
+	documentBundle := make(map[string]string, len(policyFiles))
 	for _, f := range policyFiles {
 		if f.IsDir() {
 			continue
 		}
 		filePath := filepath.Join(directoryPath, f.Name()) //get absolute file path
-		fileContent, err := ioutil.ReadFile(filepath.Clean(filePath))
+		fileContent, err := os.ReadFile(filepath.Clean(filePath))
 		if err != nil {
 			return nil, fmt.Errorf("failed to read file: %w", err)
 		}

--- a/cpa/parsing_test.go
+++ b/cpa/parsing_test.go
@@ -91,12 +91,12 @@ func TestLoadPolicyFile(t *testing.T) {
 		{
 			Name:        "fails on non-existing filePath",
 			FilePath:    "./testdata/does_not_exist",
-			ExpectedErr: "failed to read file: open ./testdata/does_not_exist: no such file or directory",
+			ExpectedErr: "failed to read file: open testdata/does_not_exist: no such file or directory",
 		},
 		{
 			Name:        "fails if filePath is a directory",
 			FilePath:    "./testdata",
-			ExpectedErr: "failed to read file: read ./testdata: is a directory",
+			ExpectedErr: "failed to read file: read testdata: is a directory",
 		},
 		{
 			Name:     "successfully parses given filePath",

--- a/cpa/testdata/multiple_policies/policy1.rego
+++ b/cpa/testdata/multiple_policies/policy1.rego
@@ -1,0 +1,1 @@
+package org

--- a/cpa/testdata/multiple_policies/policy2.rego
+++ b/cpa/testdata/multiple_policies/policy2.rego
@@ -1,0 +1,1 @@
+package org


### PR DESCRIPTION
## Rationale
This PR Adds methods for loading policies from filesystem

## Considerations
- Creating two different methods for FILE and DIRECTORY instead of a single method.
- Currently put the new methods in parsing.go, can be moved to a separate file in future if seems fit.

## Changes

- Added LoadPolicyFile method
- Added LoadPolicyDirectory method
- Added tests for the new methods
