### PR TITLE
added Meta Option to Policy-Agent evaluation

### DIFF
--- a/cpa/parsing_test.go
+++ b/cpa/parsing_test.go
@@ -131,7 +131,7 @@ func TestLoadPolicyDirectory(t *testing.T) {
 		{
 			Name:          "fails if directoryPath is a file",
 			DirectoryPath: "./testdata/multiple_policies/policy1.rego",
-			ExpectedErr:   "failed to get list of policy files: readdirent ./testdata/multiple_policies/policy1.rego: not a directory",
+			ExpectedErr:   "./testdata/multiple_policies/policy1.rego: not a directory",
 		},
 		{
 			Name:          "successfully parses given directoryPath",
@@ -146,7 +146,8 @@ func TestLoadPolicyDirectory(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, policy)
 			} else {
-				require.EqualError(t, err, tc.ExpectedErr)
+				require.NotNil(t, err, "expected error to not be nil")
+				require.Contains(t, err.Error(), tc.ExpectedErr)
 			}
 		})
 	}

--- a/cpa/policy.go
+++ b/cpa/policy.go
@@ -14,7 +14,7 @@ type Policy struct {
 	compiler *ast.Compiler
 }
 
-// Eval will run native OPA against your document, input, and evaluate the query.
+// Eval will run native OPA query against your document, input, and apply any evaluation options.
 // It returns raw OPA expression values.
 func (policy Policy) Eval(ctx context.Context, query string, input interface{}, opts ...EvalOption) (interface{}, error) {
 	input, err := convertYAMLMapKeyTypes(input, nil)
@@ -61,7 +61,7 @@ func (policy Policy) Eval(ctx context.Context, query string, input interface{}, 
 	return values, nil
 }
 
-// Decide takes an input and evaluates it against a policy.
+// Decide takes an input and evaluates it against a policy. Evaluation options will be passed down to policy.Eval
 func (policy Policy) Decide(ctx context.Context, input interface{}, opts ...EvalOption) (*Decision, error) {
 	data, err := policy.Eval(ctx, "data", input, opts...)
 	if err != nil {

--- a/cpa/policy.go
+++ b/cpa/policy.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
+	"github.com/open-policy-agent/opa/storage/inmem"
 )
 
 type Policy struct {
@@ -15,13 +16,28 @@ type Policy struct {
 
 // Eval will run native OPA against your document, input, and evaluate the query.
 // It returns raw OPA expression values.
-func (policy Policy) Eval(ctx context.Context, query string, input interface{}) (interface{}, error) {
+func (policy Policy) Eval(ctx context.Context, query string, input interface{}, opts ...EvalOption) (interface{}, error) {
 	input, err := convertYAMLMapKeyTypes(input, nil)
 	if err != nil {
 		return nil, fmt.Errorf("invalid value: %w", err)
 	}
 
-	q, err := rego.New(rego.Compiler(policy.compiler), rego.Query(query), rego.Input(input)).PrepareForEval(ctx)
+	var options evalOptions
+	for _, apply := range opts {
+		apply(&options)
+	}
+
+	regoOptions := []func(*rego.Rego){
+		rego.Compiler(policy.compiler),
+		rego.Query(query),
+		rego.Input(input),
+	}
+
+	if options.storage != nil {
+		regoOptions = append(regoOptions, rego.Store(inmem.NewFromObject(options.storage)))
+	}
+
+	q, err := rego.New(regoOptions...).PrepareForEval(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare context for evaluation: %w", err)
 	}
@@ -46,8 +62,8 @@ func (policy Policy) Eval(ctx context.Context, query string, input interface{}) 
 }
 
 // Decide takes an input and evaluates it against a policy.
-func (policy Policy) Decide(ctx context.Context, input interface{}) (*Decision, error) {
-	data, err := policy.Eval(ctx, "data", input)
+func (policy Policy) Decide(ctx context.Context, input interface{}, opts ...EvalOption) (*Decision, error) {
+	data, err := policy.Eval(ctx, "data", input, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to evaluate the query: %w", err)
 	}

--- a/cpa/policy_decide_test.go
+++ b/cpa/policy_decide_test.go
@@ -10,6 +10,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type DecideTestCase struct {
+	Name     string
+	Document string
+	Config   string
+	Error    error
+	Decision *Decision
+}
+
 var lintingCases = []DecideTestCase{
 	{
 		Name:     "error if package name is not org",

--- a/cpa/policy_eval_options.go
+++ b/cpa/policy_eval_options.go
@@ -1,0 +1,17 @@
+package cpa
+
+type evalOptions struct {
+	storage map[string]interface{}
+}
+
+type EvalOption func(*evalOptions)
+
+// Meta is an option that sets the data.meta property during policy evaluation.
+func Meta(value interface{}) EvalOption {
+	return func(option *evalOptions) {
+		if option.storage == nil {
+			option.storage = make(map[string]interface{})
+		}
+		option.storage["meta"] = value
+	}
+}

--- a/cpa/policy_test.go
+++ b/cpa/policy_test.go
@@ -111,7 +111,6 @@ func TestDocumentQuery(t *testing.T) {
 			not product[name]
 		}
 	`})
-
 	if err != nil {
 		t.Fatalf("failed to parse rego document for testing: %v", err)
 	}
@@ -181,7 +180,6 @@ func TestBundleQuery(t *testing.T) {
 			}
 		`,
 	})
-
 	if err != nil {
 		t.Fatalf("failed to parse bundle for testing: %v", err)
 	}
@@ -206,10 +204,24 @@ func TestBundleQuery(t *testing.T) {
 	)
 }
 
-type DecideTestCase struct {
-	Name     string
-	Document string
-	Config   string
-	Error    error
-	Decision *Decision
+func TestMeta(t *testing.T) {
+	policy, err := ParseBundle(map[string]string{
+		"test.rego": `
+			package org
+			
+			meta = data.meta
+		`,
+	})
+
+	require.NoError(t, err)
+
+	metadata := map[string]interface{}{
+		"key":  "value",
+		"test": true,
+	}
+
+	value, err := policy.Eval(context.Background(), "data.org.meta", nil, Meta(metadata))
+	require.NoError(t, err)
+
+	require.EqualValues(t, metadata, value)
 }


### PR DESCRIPTION
## Rationale

Want to provide metadata to policy evaluations

## Changes

- Added EvalOptions to `policy.Decide` and `policy.Eval`
- Created Meta Option
