### PR TITLE
Seceng 686 runner helper

### DIFF
--- a/cpa/policy_decide_test.go
+++ b/cpa/policy_decide_test.go
@@ -530,8 +530,8 @@ var runnerCases = []DecideTestCase{
 			Status:       "SOFT_FAIL",
 			EnabledRules: []string{"check_resource_class"},
 			SoftFailures: []Violation{
-				{Rule: "check_resource_class", Reason: "project \"B\" is not allowed to use resource_class \"large\" declared in job \"test\""},
-				{Rule: "check_resource_class", Reason: "project \"B\" is not allowed to use resource_class \"small\" declared in job \"build\""},
+				{Rule: "check_resource_class", Reason: "project is not allowed to use resource_class \"large\" declared in job \"test\""},
+				{Rule: "check_resource_class", Reason: "project is not allowed to use resource_class \"small\" declared in job \"build\""},
 			},
 		},
 	},

--- a/cpa/policy_decide_test.go
+++ b/cpa/policy_decide_test.go
@@ -535,6 +535,26 @@ var runnerCases = []DecideTestCase{
 			},
 		},
 	},
+	{
+		Name: "does not affect unspecified resource classes",
+		Document: `
+			package org
+			import data.circleci.config
+			policy_name = "runner_test"
+
+			enable_rule["check_resource_class"]
+
+			check_resource_class = config.resource_class_by_project({"large": {"A"}})
+		`,
+		Config: `{
+			"jobs": { "lint": { "resource_class": "medium" } }
+		}`,
+		Metadata: map[string]interface{}{
+			"project_id": "B",
+		},
+		Error:    nil,
+		Decision: &Decision{Status: "PASS", EnabledRules: []string{"check_resource_class"}},
+	},
 }
 
 func TestDecide(t *testing.T) {

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -9,15 +9,19 @@ import (
 
 var (
 	//go:embed rego/jobs.rego
-	JobsRego string
+	jobsRego string
 
 	//go:embed rego/orbs.rego
-	OrbsRego string
+	orbsRego string
+
+	//go:embed rego/runner.rego
+	runnerRego string
 )
 
 var configHelpers = map[string]string{
-	"circleci_jobs_helper.rego": JobsRego,
-	"circleci_orbs_helper.rego": OrbsRego,
+	"circleci_jobs_helper.rego":   jobsRego,
+	"circleci_orbs_helper.rego":   orbsRego,
+	"circleci_runner_helper.rego": runnerRego,
 }
 
 var configHelpersMap = make(map[string]*ast.Module, len(configHelpers))

--- a/internal/helpers/rego/runner.rego
+++ b/internal/helpers/rego/runner.rego
@@ -5,5 +5,5 @@ resource_class_by_project(reservered_classes_to_projects) = {reason |
         class = input.jobs[name].resource_class
         allowed_projects = reservered_classes_to_projects[class]
         not allowed_projects[data.meta.project_id]
-        reason := sprintf("project %q is not allowed to use resource_class %q declared in job %q", [data.meta.project_id, class, name])
+        reason := sprintf("project is not allowed to use resource_class %q declared in job %q", [class, name])
 }

--- a/internal/helpers/rego/runner.rego
+++ b/internal/helpers/rego/runner.rego
@@ -1,0 +1,8 @@
+package circleci.config
+
+resource_class_by_project(reservered_classes_to_projects) = {reason | 
+        some name
+        class = input.jobs[name].resource_class
+        not reservered_classes_to_projects[class][data.meta.project_id]
+        reason := sprintf("project %q is not allowed to use resource_class %q declared in job %q", [data.meta.project_id, class, name])
+}

--- a/internal/helpers/rego/runner.rego
+++ b/internal/helpers/rego/runner.rego
@@ -3,6 +3,7 @@ package circleci.config
 resource_class_by_project(reservered_classes_to_projects) = {reason | 
         some name
         class = input.jobs[name].resource_class
-        not reservered_classes_to_projects[class][data.meta.project_id]
+        allowed_projects = reservered_classes_to_projects[class]
+        not allowed_projects[data.meta.project_id]
         reason := sprintf("project %q is not allowed to use resource_class %q declared in job %q", [data.meta.project_id, class, name])
 }


### PR DESCRIPTION
## Rationale

The runner team want a way to map certain resource_classes to certain sets of projects.
The easiest approach was to create this functionality as a built in helper function. 

## Changes

- added `runner.rego` which exposes function `resource_class_by_project`
