### PR TITLE
(SNC-48) Update CODEOWNERS to security-controls team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @CircleCI-Public/security-engineering
+* @CircleCI-Public/security-controls


### PR DESCRIPTION
Updates CODEOWNERS to [Security & Controls](https://github.com/orgs/CircleCI-Public/teams/security-controls) team