### PR TITLE
add decision errors

### DIFF
--- a/cpa/decision.go
+++ b/cpa/decision.go
@@ -19,7 +19,7 @@ type Violation struct {
 // Decision is a circleci flavoured output representing a policy decision.
 type Decision struct {
 	Status       Status      `json:"status"`
-	Cause        string      `json:"cause,omitempty"`
+	Reason       string      `json:"reason,omitempty"`
 	EnabledRules []string    `json:"enabled_rules,omitempty"`
 	HardFailures []Violation `json:"hard_failures,omitempty"`
 	SoftFailures []Violation `json:"soft_failures,omitempty"`

--- a/cpa/decision.go
+++ b/cpa/decision.go
@@ -8,6 +8,7 @@ const (
 	StatusPass     Status = "PASS"
 	StatusSoftFail Status = "SOFT_FAIL"
 	StatusHardFail Status = "HARD_FAIL"
+	StatusError    Status = "ERROR"
 )
 
 type Violation struct {
@@ -18,6 +19,7 @@ type Violation struct {
 // Decision is a circleci flavoured output representing a policy decision.
 type Decision struct {
 	Status       Status      `json:"status"`
+	Cause        string      `json:"cause,omitempty"`
 	EnabledRules []string    `json:"enabled_rules,omitempty"`
 	HardFailures []Violation `json:"hard_failures,omitempty"`
 	SoftFailures []Violation `json:"soft_failures,omitempty"`

--- a/cpa/decision_test.go
+++ b/cpa/decision_test.go
@@ -12,7 +12,7 @@ func TestJsonOutput(t *testing.T) {
 	t.Run("omitempty", func(t *testing.T) {
 		d := Decision{
 			Status:       "",
-			Cause:        "",
+			Reason:       "",
 			EnabledRules: nil,
 			HardFailures: nil,
 			SoftFailures: nil,
@@ -29,7 +29,7 @@ func TestJsonOutput(t *testing.T) {
 	t.Run("key names", func(t *testing.T) {
 		d := Decision{
 			Status:       "",
-			Cause:        "cause",
+			Reason:       "cause",
 			EnabledRules: []string{""},
 			HardFailures: []Violation{{}},
 			SoftFailures: []Violation{{}},
@@ -53,7 +53,7 @@ func TestJsonOutput(t *testing.T) {
 
 		require.EqualValues(
 			t,
-			[]string{"cause", "enabled_rules", "hard_failures", "soft_failures", "status"},
+			[]string{"enabled_rules", "hard_failures", "reason", "soft_failures", "status"},
 			keys,
 		)
 	})

--- a/cpa/decision_test.go
+++ b/cpa/decision_test.go
@@ -12,6 +12,7 @@ func TestJsonOutput(t *testing.T) {
 	t.Run("omitempty", func(t *testing.T) {
 		d := Decision{
 			Status:       "",
+			Cause:        "",
 			EnabledRules: nil,
 			HardFailures: nil,
 			SoftFailures: nil,
@@ -28,6 +29,7 @@ func TestJsonOutput(t *testing.T) {
 	t.Run("key names", func(t *testing.T) {
 		d := Decision{
 			Status:       "",
+			Cause:        "cause",
 			EnabledRules: []string{""},
 			HardFailures: []Violation{{}},
 			SoftFailures: []Violation{{}},
@@ -51,7 +53,7 @@ func TestJsonOutput(t *testing.T) {
 
 		require.EqualValues(
 			t,
-			[]string{"enabled_rules", "hard_failures", "soft_failures", "status"},
+			[]string{"cause", "enabled_rules", "hard_failures", "soft_failures", "status"},
 			keys,
 		)
 	})

--- a/cpa/policy.go
+++ b/cpa/policy.go
@@ -75,7 +75,10 @@ func (policy Policy) Decide(ctx context.Context, input interface{}, opts ...Eval
 
 	data, err := policy.Eval(ctx, "data", input, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to evaluate the query: %w", err)
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return nil, err
+		}
+		return &Decision{Status: StatusError, Cause: err.Error()}, nil
 	}
 
 	output, ok := data.(map[string]interface{})

--- a/cpa/policy.go
+++ b/cpa/policy.go
@@ -78,7 +78,7 @@ func (policy Policy) Decide(ctx context.Context, input interface{}, opts ...Eval
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return nil, err
 		}
-		return &Decision{Status: StatusError, Cause: err.Error()}, nil
+		return &Decision{Status: StatusError, Reason: err.Error()}, nil
 	}
 
 	output, ok := data.(map[string]interface{})

--- a/cpa/policy_test.go
+++ b/cpa/policy_test.go
@@ -469,6 +469,6 @@ func TestPolicyRuntimeError(t *testing.T) {
 	require.Equal(
 		t,
 		"policy.rego:5: eval_conflict_error: complete rules must not produce multiple outputs",
-		decision.Cause,
+		decision.Reason,
 	)
 }


### PR DESCRIPTION
## Rationale

Evaluation Errors are being surfaced as errors when making decisions. However policies may fail at runtime, and although this is indeed an error it is not an exceptional one.

We have decided that evaluation errors should create a decision with state Error and Cause. This allows systems that integrate with the Polcy-Agent to handle runtime errors separate from fatal errors (parsing, unexpected output format and so on).

## Considerations

I considered an alternative approach where we could simply wrap eval errors in a EvalError type. However if runtime errors can be in the normal flow of taking a decision it seems more natural to create a new decision state.

## Changes
- added new Error decision state
- added new Cause decision field
- return new Error decision on evaluation errors