### PR TITLE
[SNC-96] Add vuln-scan to project

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  snyk-vuln-scanner: cci-internal/snyk-vuln-scanner@0.3.0
+
 executors:
   go:
     docker:
@@ -56,6 +59,10 @@ workflows:
     jobs:
       - lint
       - test
+      - snyk-vuln-scanner/vuln-scan:
+          context: [org-global, org-global-employees]
+          snyk-organization-name: "CircleCI-Public"
+          current-branch: << pipeline.git.branch >>
       - publish:
           requires:
             - lint


### PR DESCRIPTION
## Rationale

Go projects scanned through the GitHub Importer lack the complete source code and thus lacks package-level information to correctly understand what dependency versions are really in use. [Learn more]()

Using the new [snyk-vulnerability-scanner-orb]() will fix this problem and upload valid data.

## Considerations

Manual scan would work but it would also be a PITA to do regularly.

## Changes

- added new Orb
- added new vuln-scan job
