### PR TITLE
add sentinal error when no policies are found from FS

### DIFF
--- a/cpa/fs.go
+++ b/cpa/fs.go
@@ -1,11 +1,14 @@
 package cpa
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 )
+
+var ErrNoPolicies = errors.New("no rego policies found")
 
 // LoadPolicyFromFS takes a filesystem path to load policy files from. It returns a parsed policy.
 // If the path is a file that policy is loaded as a bundle of 1 file. If the path is a directory that
@@ -28,7 +31,7 @@ func LoadPolicyFromFS(root string) (*Policy, error) {
 	}
 
 	if len(files) == 0 {
-		return nil, fmt.Errorf("no rego policies found at path: %q", root)
+		return nil, ErrNoPolicies
 	}
 
 	bundle := make(map[string]string, len(files))

--- a/cpa/fs_test.go
+++ b/cpa/fs_test.go
@@ -37,7 +37,7 @@ func TestLoadPolicyFromFS(t *testing.T) {
 		{
 			Name:        "fails when loading non-rego file",
 			Path:        "./testdata/mixed_ext/policy.text",
-			ExpectedErr: "no rego policies found at path",
+			ExpectedErr: "no rego policies found",
 		},
 		{
 			Name:             "only load rego files",


### PR DESCRIPTION
## Rationale

Some code may want to handle the case when loading a policy from the filesystem where no policies are found.
This change would allow the consuming code to check for this error:

```go
policy, err := cpa.LoadPolicyFromFS("./my_path")
if err != nil {
  if errors.Is(err, cpa.ErrNoPolicies) {
     // handle differently
  }
  // handle error!
}
```

Currently the only way to check for this error is by doing string comparisons which is flaky.

