### PR TITLE
(SNC-11) Rego Policy Pretty-Print

### DIFF
--- a/cpa/parsing.go
+++ b/cpa/parsing.go
@@ -100,9 +100,9 @@ func parseBundle(bundle map[string]string, rules ...LintRule) (*Policy, error) {
 			continue
 		}
 
-		moduleMap[file] = mod
+		moduleMap[name] = mod
+		source[name] = rego
 		nameCount[name]++
-		source[name] = mod.String()
 	}
 
 	if len(multiErr) > 0 {
@@ -119,10 +119,10 @@ func parseBundle(bundle map[string]string, rules ...LintRule) (*Policy, error) {
 		return nil, fmt.Errorf("failed to parse bundle: %w", multiErr)
 	}
 
-	for filename, mod := range moduleMap {
+	for policyName, mod := range moduleMap {
 		for _, rule := range rules {
 			if err := rule(mod); err != nil {
-				multiErr = append(multiErr, fmt.Errorf("lint error: %q: %w", filename, err))
+				multiErr = append(multiErr, fmt.Errorf("lint error: %q: %w", policyName, err))
 			}
 		}
 	}

--- a/cpa/parsing_test.go
+++ b/cpa/parsing_test.go
@@ -49,7 +49,7 @@ func TestRegoParsing(t *testing.T) {
 			`,
 			LintRules: []LintRule{AllowedPackages("good", "righteous")},
 			//nolint
-			Error: errors.New(`failed policy linting: lint error: "test.rego": invalid package name: expected one of packages [good, righteous] but got "package evil"`),
+			Error: errors.New(`failed policy linting: lint error: "test": invalid package name: expected one of packages [good, righteous] but got "package evil"`),
 		},
 		{
 			Name: "passes package name linting",


### PR DESCRIPTION
## Rationale

What was overarching product goal of this PR? Is there any pertinent history or
context that reviewers should know?

- The goal of these changes is to facilitate pretty-printing of policies


## Considerations

Why did you make some of the technical decisions you did in implementing this PR?
Were any other approaches considered and rejected?

This is the second iteration of changes to be made to achieve the goal mentioned above. The team closed https://github.com/circleci/policy-service/pull/258 after deciding it would be more beneficial, from a customer perspective and in terms of extensibility and maintainability, to modify the `policy-agent` code instead of the service's. 

## Changes

- Modified `policy.Source()` so that it returns a map of the `policy_name` to non-normalized source content.
- Modified `policy.Modules()` so that it returns a map of the `policy_name` to modules instead of using the `filename` as key.
- Updated all relevant tests to validate that the contents of the `bundle` and `policy.Source()` maps are equal
- Moved the test `TestBundleLinksHelpers` to its own function to validate that all relevant imports are added to the policy.
