### PR TITLE
[SNC-170] Snyk scanning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  snyk: snyk/snyk@1.4.0
+
 executors:
   go:
     docker:
@@ -51,11 +54,26 @@ jobs:
             git tag -a "v0.0.$CIRCLE_BUILD_NUM" -m "Release v0.0.$CIRCLE_BUILD_NUM"
             git push origin "v0.0.$CIRCLE_BUILD_NUM"
 
+  vulnerability-scan:
+    executor: go
+    steps:
+      - checkout
+      - snyk/scan:
+          fail-on-issues: false
+          severity-threshold: high
+          monitor-on-build: true
+          project: '${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}'
+
 workflows:
   publish:
     jobs:
       - lint
       - test
+      - vulnerability-scan:
+          context: org-global-employees
+          requires:
+            - lint
+            - test
       - publish:
           requires:
             - lint


### PR DESCRIPTION
## Rationale
Enable Snyk scanning for circle-policy-agent project

## Considerations
- Running the scanning for all branches.
- Requiring test and lint jobs to pass before performing the scan
