### PR TITLE
(SNC-101) Allow enable_hard key when evaluating policy decisions

### DIFF
--- a/cpa/policy.go
+++ b/cpa/policy.go
@@ -108,6 +108,14 @@ func (policy Policy) Decide(ctx context.Context, input interface{}, opts ...Eval
 		return nil, fmt.Errorf("invalid hard_fail: %w", err)
 	}
 
+	enabledHardFailRules, err := asStringSlice(org["enable_hard"])
+	if err != nil {
+		return nil, fmt.Errorf("invalid enable_hard: %w", err)
+	}
+
+	hardFailRules = append(hardFailRules, enabledHardFailRules...)
+	enabledRules = append(enabledRules, enabledHardFailRules...)
+
 	hardFailMap := make(map[string]struct{})
 	for _, rule := range hardFailRules {
 		hardFailMap[rule] = struct{}{}

--- a/cpa/policy.go
+++ b/cpa/policy.go
@@ -114,11 +114,21 @@ func (policy Policy) Decide(ctx context.Context, input interface{}, opts ...Eval
 	}
 
 	hardFailRules = append(hardFailRules, enabledHardFailRules...)
-	enabledRules = append(enabledRules, enabledHardFailRules...)
 
 	hardFailMap := make(map[string]struct{})
 	for _, rule := range hardFailRules {
 		hardFailMap[rule] = struct{}{}
+	}
+
+	enabledRulesMap := make(map[string]struct{})
+	for _, rule := range enabledRules {
+		enabledRulesMap[rule] = struct{}{}
+	}
+
+	for _, rule := range enabledHardFailRules {
+		if _, ok := enabledRulesMap[rule]; !ok {
+			enabledRules = append(enabledRules, rule)
+		}
 	}
 
 	decision := Decision{EnabledRules: enabledRules}

--- a/cpa/policy_test.go
+++ b/cpa/policy_test.go
@@ -497,3 +497,28 @@ func TestPolicyRuntimeError(t *testing.T) {
 		decision.Reason,
 	)
 }
+
+func TestEnableHard(t *testing.T) {
+	policy, err := ParseBundle(map[string]string{
+		"policy.rego": `
+			package org
+			policy_name["policy"]
+			some_rule = "my rule"
+			enable_hard["some_rule"]
+		`,
+	})
+	require.NoError(t, err)
+
+	v := []Violation{
+		{
+			Rule:   "some_rule",
+			Reason: "my rule",
+		},
+	}
+
+	decision, err := policy.Decide(context.Background(), nil)
+	require.NoError(t, err)
+	require.Equal(t, StatusHardFail, decision.Status)
+	require.Contains(t, "some_rule", decision.Reason)
+	require.Equal(t, v, decision.HardFailures)
+}

--- a/cpa/policy_test.go
+++ b/cpa/policy_test.go
@@ -497,28 +497,3 @@ func TestPolicyRuntimeError(t *testing.T) {
 		decision.Reason,
 	)
 }
-
-func TestEnableHard(t *testing.T) {
-	policy, err := ParseBundle(map[string]string{
-		"policy.rego": `
-			package org
-			policy_name["policy"]
-			some_rule = "my rule"
-			enable_hard["some_rule"]
-		`,
-	})
-	require.NoError(t, err)
-
-	v := []Violation{
-		{
-			Rule:   "some_rule",
-			Reason: "my rule",
-		},
-	}
-
-	decision, err := policy.Decide(context.Background(), nil)
-	require.NoError(t, err)
-	require.Equal(t, StatusHardFail, decision.Status)
-	require.Contains(t, "some_rule", decision.Reason)
-	require.Equal(t, v, decision.HardFailures)
-}

--- a/cpa/tester/policies/common/enable_hard/policy.rego
+++ b/cpa/tester/policies/common/enable_hard/policy.rego
@@ -2,6 +2,8 @@ package org
 
 policy_name["enable_hard"]
 
+# if enabled twice, the violation should only be reported once
+enable_rule["some_hard_rule"]
 enable_hard["some_hard_rule"]
 
 some_hard_rule = "this hard rule was enabled in one line - cool!"

--- a/cpa/tester/policies/common/enable_hard/policy.rego
+++ b/cpa/tester/policies/common/enable_hard/policy.rego
@@ -3,7 +3,10 @@ package org
 policy_name["enable_hard"]
 
 # if enabled twice, the violation should only be reported once
-enable_rule["some_hard_rule"]
+enable_rule["double_enabled_rule"]
+enable_hard["double_enabled_rule"]
+
 enable_hard["some_hard_rule"]
 
+double_enabled_rule = "this hard rule was enabled twice but reported once"
 some_hard_rule = "this hard rule was enabled in one line - cool!"

--- a/cpa/tester/policies/common/enable_hard/policy.rego
+++ b/cpa/tester/policies/common/enable_hard/policy.rego
@@ -1,0 +1,7 @@
+package org
+
+policy_name["enable_hard"]
+
+enable_hard["some_hard_rule"]
+
+some_hard_rule = "this hard rule was enabled in one line - cool!"

--- a/cpa/tester/policies/common/enable_hard/policy_test.yaml
+++ b/cpa/tester/policies/common/enable_hard/policy_test.yaml
@@ -2,7 +2,10 @@ test_enable_hard:
   decision:
     status: HARD_FAIL
     enabled_rules:
+      - double_enabled_rule
       - some_hard_rule
     hard_failures:
+      - rule: double_enabled_rule
+        reason: this hard rule was enabled twice but reported once
       - rule: some_hard_rule
         reason: this hard rule was enabled in one line - cool!

--- a/cpa/tester/policies/common/enable_hard/policy_test.yaml
+++ b/cpa/tester/policies/common/enable_hard/policy_test.yaml
@@ -1,0 +1,8 @@
+test_enable_hard:
+  decision:
+    status: HARD_FAIL
+    enabled_rules:
+      - some_hard_rule
+    hard_failures:
+      - rule: some_hard_rule
+        reason: this hard rule was enabled in one line - cool!

--- a/cpa/tester/policies/results.json
+++ b/cpa/tester/policies/results.json
@@ -99,6 +99,13 @@
   },
   {
     "Passed": true,
+    "Group": "policies/common/enable_hard",
+    "Name": "test_enable_hard",
+    "Elapsed": "0s",
+    "ElapsedMS": 0
+  },
+  {
+    "Passed": true,
     "Group": "policies/common/error",
     "Name": "test_error",
     "Elapsed": "0s",

--- a/cpa/tester/policies/results.xml
+++ b/cpa/tester/policies/results.xml
@@ -1,4 +1,4 @@
-<testsuites name="root" tests="47" failures="0" errors="0" time="0">
+<testsuites name="root" tests="48" failures="0" errors="0" time="0">
 	<testsuite tests="9" failures="0" time="0" name="&lt;opa.tests&gt;" timestamp="">
 		<properties></properties>
 		<testcase classname="&lt;opa.tests&gt;" name="data.org.test_to_array_scalar" time="0"></testcase>
@@ -26,6 +26,10 @@
 		<testcase classname="policies/common/base" name="test_base_policy" time="0"></testcase>
 		<testcase classname="policies/common/base" name="test_base_policy/not_bob" time="0"></testcase>
 		<testcase classname="policies/common/base" name="test_base_policy/not_bob/hard_fail" time="0"></testcase>
+	</testsuite>
+	<testsuite tests="1" failures="0" time="0" name="policies/common/enable_hard" timestamp="">
+		<properties></properties>
+		<testcase classname="policies/common/enable_hard" name="test_enable_hard" time="0"></testcase>
 	</testsuite>
 	<testsuite tests="1" failures="0" time="0" name="policies/common/error" timestamp="">
 		<properties></properties>

--- a/cpa/tester/runner_test.go
+++ b/cpa/tester/runner_test.go
@@ -40,6 +40,7 @@ func TestRunner(t *testing.T) {
 		"policies",
 		"policies/common",
 		"policies/common/base",
+		"policies/common/enable_hard",
 		"policies/common/error",
 		"policies/common/no_enabled_rules",
 		"policies/common/reason_types",


### PR DESCRIPTION
## Rationale

It is currently more verbose and error prone than it needs to be to declare hard failure rules.
One must enable it, and then declare its violation level with two stanzas that require the rule name be typed correctly.
This solution allows a policy user to declare a rule as hard and enable it in one line.

Before:
```
enable_rule["my_rule"]
hard_fail["my_rule"]

my_rule[reason] { ... rule body ... }
```

After:
```
enable_hard["my_rule"]
my_rule[reason] { ... rule body ... }
```

## Considerations

Why did you make some of the technical decisions you did in implementing this PR?
Were any other approaches considered and rejected?

## Changes

- Decision evaluation now interprets the output of `enable_hard` and adds those rules to both the `enabled rule` list and `hard failure` list
- Created tests to validate the new functionality
