### PR TITLE
chore(deps): update exp module

### DIFF
--- a/cpa/tester/runner.go
+++ b/cpa/tester/runner.go
@@ -1,6 +1,7 @@
 package tester
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -161,7 +162,7 @@ func (runner *Runner) runFolder(folder string, results chan<- Result) {
 		return
 	}
 
-	slices.SortFunc(namedTests, func(a, b NamedTest) bool { return a.Name < b.Name })
+	slices.SortFunc(namedTests, func(a, b NamedTest) int { return cmp.Compare(a.Name, b.Name) })
 
 	for _, t := range namedTests {
 		runner.runTest(policy, results, t, folder, ParentTestContext{})

--- a/cpa/tester/test.go
+++ b/cpa/tester/test.go
@@ -1,6 +1,7 @@
 package tester
 
 import (
+	"cmp"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -25,7 +26,7 @@ func (t Test) NamedCases() []NamedTest {
 	for name, test := range t.Cases {
 		result = append(result, NamedTest{name, test})
 	}
-	slices.SortFunc(result, func(a, b NamedTest) bool { return a.Name < b.Name })
+	slices.SortFunc(result, func(a, b NamedTest) int { return cmp.Compare(a.Name, b.Name) })
 	return result
 }
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/open-policy-agent/opa v0.54.0
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/stretchr/testify v1.8.3
-	golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1
+	golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,8 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1 h1:MGwJjxBy0HJshjDNfLsYO8xppfqWlA5ZT9OhtUUhTNw=
 golang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
+golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb h1:c0vyKkb6yr3KR7jEfJaOSv4lG7xPkbN6r52aJz1d8a8=
+golang.org/x/exp v0.0.0-20231206192017-f3f8817b8deb/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=


### PR DESCRIPTION
## Rationale

The `slices` package in the `golang.org/x/exp` has changed the signature of comparison functions from [returning a `bool`](https://pkg.go.dev/golang.org/x/exp@v0.0.0-20230713183714-613f0c0eb8a1/slices#SortFunc) to [returning an `int`](https://pkg.go.dev/golang.org/x/exp@v0.0.0-20230728194245-b0cb94b80691/slices#SortFunc).

This breaking change impacts Go programs relying on `circle-policy-agent` with a more recent version of the `exp` module, and prevents them from building.

```
circle-policy-agent@v0.0.702/cpa/tester/runner.go:164:30: type func(a NamedTest, b NamedTest) bool of func(a, b NamedTest) bool {…} does not match inferred type func(a NamedTest, b NamedTest) int for func(a E, b E) int
```

This PR updates the `exp` package and fixes the usage of `slices.SortFunc` to reflect the new signature.

## Changes

* Update the `golang.org/x/exp` module to `v0.0.0-20231206192017-f3f8817b8deb`
* Fix usage of `slices.SortFunc` to reflect breaking changes in the `golang.org/x/exp` module
