### PR TITLE
[SNC-561] Update build image to Go 1.20.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   go:
     docker:
-      - image: cimg/go:1.20
+      - image: cimg/go:1.20.12
     environment:
       CGO_ENABLED: 0
 


### PR DESCRIPTION
## Rationale

Bumping the alpine container image to one that contains Go 1.20.12 in order to address vulnerabilities. 

## Changes

- Update container image used to build agent binary