### PR TITLE
add timestamp to JUnit output format.

### DIFF
--- a/cpa/tester/policies/results.xml
+++ b/cpa/tester/policies/results.xml
@@ -1,5 +1,5 @@
 <testsuites name="root" tests="54" failures="0" errors="0" time="0">
-	<testsuite tests="12" failures="0" time="0" name="&lt;opa.tests&gt;" timestamp="">
+	<testsuite tests="12" failures="0" time="0" name="&lt;opa.tests&gt;" timestamp="2024-03-04T10:50:05Z">
 		<properties></properties>
 		<testcase classname="&lt;opa.tests&gt;" name="data.org.test_to_array_scalar" time="0"></testcase>
 		<testcase classname="&lt;opa.tests&gt;" name="data.org.test_to_array_array" time="0"></testcase>
@@ -14,56 +14,56 @@
 		<testcase classname="&lt;opa.tests&gt;" name="data.org.test_is_parameterized_expression_for_pipeline_true" time="0"></testcase>
 		<testcase classname="&lt;opa.tests&gt;" name="data.org.test_is_parameterized_expression_false" time="0"></testcase>
 	</testsuite>
-	<testsuite tests="0" failures="0" time="0" name="policies" timestamp="">
+	<testsuite tests="0" failures="0" time="0" name="policies" timestamp="2024-03-04T10:50:05Z">
 		<properties>
 			<property name="skipped" value="no tests"></property>
 		</properties>
 	</testsuite>
-	<testsuite tests="0" failures="0" time="0" name="policies/common" timestamp="">
+	<testsuite tests="0" failures="0" time="0" name="policies/common" timestamp="2024-03-04T10:50:05Z">
 		<properties>
 			<property name="skipped" value="no tests"></property>
 		</properties>
 	</testsuite>
-	<testsuite tests="3" failures="0" time="0" name="policies/common/base" timestamp="">
+	<testsuite tests="3" failures="0" time="0" name="policies/common/base" timestamp="2024-03-04T10:50:05Z">
 		<properties></properties>
 		<testcase classname="policies/common/base" name="test_base_policy" time="0"></testcase>
 		<testcase classname="policies/common/base" name="test_base_policy/not_bob" time="0"></testcase>
 		<testcase classname="policies/common/base" name="test_base_policy/not_bob/hard_fail" time="0"></testcase>
 	</testsuite>
-	<testsuite tests="1" failures="0" time="0" name="policies/common/enable_hard" timestamp="">
+	<testsuite tests="1" failures="0" time="0" name="policies/common/enable_hard" timestamp="2024-03-04T10:50:05Z">
 		<properties></properties>
 		<testcase classname="policies/common/enable_hard" name="test_enable_hard" time="0"></testcase>
 	</testsuite>
-	<testsuite tests="1" failures="0" time="0" name="policies/common/error" timestamp="">
+	<testsuite tests="1" failures="0" time="0" name="policies/common/error" timestamp="2024-03-04T10:50:05Z">
 		<properties></properties>
 		<testcase classname="policies/common/error" name="test_error" time="0"></testcase>
 	</testsuite>
-	<testsuite tests="1" failures="0" time="0" name="policies/common/no_enabled_rules" timestamp="">
+	<testsuite tests="1" failures="0" time="0" name="policies/common/no_enabled_rules" timestamp="2024-03-04T10:50:05Z">
 		<properties></properties>
 		<testcase classname="policies/common/no_enabled_rules" name="test_no_enabled_rules" time="0"></testcase>
 	</testsuite>
-	<testsuite tests="4" failures="0" time="0" name="policies/common/reason_types" timestamp="">
+	<testsuite tests="4" failures="0" time="0" name="policies/common/reason_types" timestamp="2024-03-04T10:50:05Z">
 		<properties></properties>
 		<testcase classname="policies/common/reason_types" name="test_reason_types" time="0"></testcase>
 		<testcase classname="policies/common/reason_types" name="test_reason_types/array" time="0"></testcase>
 		<testcase classname="policies/common/reason_types" name="test_reason_types/map" time="0"></testcase>
 		<testcase classname="policies/common/reason_types" name="test_reason_types/string" time="0"></testcase>
 	</testsuite>
-	<testsuite tests="1" failures="0" time="0" name="policies/common/soft_and_hard_fail_together" timestamp="">
+	<testsuite tests="1" failures="0" time="0" name="policies/common/soft_and_hard_fail_together" timestamp="2024-03-04T10:50:05Z">
 		<properties></properties>
 		<testcase classname="policies/common/soft_and_hard_fail_together" name="test_soft_and_hard_fail_together" time="0"></testcase>
 	</testsuite>
-	<testsuite tests="2" failures="0" time="0" name="policies/common/structure" timestamp="">
+	<testsuite tests="2" failures="0" time="0" name="policies/common/structure" timestamp="2024-03-04T10:50:05Z">
 		<properties></properties>
 		<testcase classname="policies/common/structure" name="test_structure/with_meta" time="0"></testcase>
 		<testcase classname="policies/common/structure" name="test_structure/with_meta/good" time="0"></testcase>
 	</testsuite>
-	<testsuite tests="0" failures="0" time="0" name="policies/helpers" timestamp="">
+	<testsuite tests="0" failures="0" time="0" name="policies/helpers" timestamp="2024-03-04T10:50:05Z">
 		<properties>
 			<property name="skipped" value="no tests"></property>
 		</properties>
 	</testsuite>
-	<testsuite tests="17" failures="0" time="0" name="policies/helpers/contexts" timestamp="">
+	<testsuite tests="17" failures="0" time="0" name="policies/helpers/contexts" timestamp="2024-03-04T10:50:05Z">
 		<properties></properties>
 		<testcase classname="policies/helpers/contexts" name="test_allowlist" time="0"></testcase>
 		<testcase classname="policies/helpers/contexts" name="test_allowlist/invalid_context" time="0"></testcase>
@@ -83,18 +83,18 @@
 		<testcase classname="policies/helpers/contexts" name="test_reservelist/test_multiple_invalid_contexts_in_job" time="0"></testcase>
 		<testcase classname="policies/helpers/contexts" name="test_reservelist/test_unreserved_contexts" time="0"></testcase>
 	</testsuite>
-	<testsuite tests="0" failures="0" time="0" name="policies/helpers/orbs" timestamp="">
+	<testsuite tests="0" failures="0" time="0" name="policies/helpers/orbs" timestamp="2024-03-04T10:50:05Z">
 		<properties>
 			<property name="skipped" value="no tests"></property>
 		</properties>
 	</testsuite>
-	<testsuite tests="3" failures="0" time="0" name="policies/helpers/orbs/allowlist" timestamp="">
+	<testsuite tests="3" failures="0" time="0" name="policies/helpers/orbs/allowlist" timestamp="2024-03-04T10:50:05Z">
 		<properties></properties>
 		<testcase classname="policies/helpers/orbs/allowlist" name="test_allow_orbs" time="0"></testcase>
 		<testcase classname="policies/helpers/orbs/allowlist" name="test_allow_orbs/bad_orb_present" time="0"></testcase>
 		<testcase classname="policies/helpers/orbs/allowlist" name="test_allow_orbs/no_orbs_present" time="0"></testcase>
 	</testsuite>
-	<testsuite tests="5" failures="0" time="0" name="policies/helpers/orbs/ban_version" timestamp="">
+	<testsuite tests="5" failures="0" time="0" name="policies/helpers/orbs/ban_version" timestamp="2024-03-04T10:50:05Z">
 		<properties></properties>
 		<testcase classname="policies/helpers/orbs/ban_version" name="test_ban_orbs" time="0"></testcase>
 		<testcase classname="policies/helpers/orbs/ban_version" name="test_ban_orbs/orb_present" time="0"></testcase>
@@ -102,32 +102,32 @@
 		<testcase classname="policies/helpers/orbs/ban_version" name="test_ban_orbs_version/exact_match" time="0"></testcase>
 		<testcase classname="policies/helpers/orbs/ban_version" name="test_ban_orbs_version/wrong_version" time="0"></testcase>
 	</testsuite>
-	<testsuite tests="3" failures="0" time="0" name="policies/helpers/runner" timestamp="">
+	<testsuite tests="3" failures="0" time="0" name="policies/helpers/runner" timestamp="2024-03-04T10:50:05Z">
 		<properties></properties>
 		<testcase classname="policies/helpers/runner" name="test_runner_helper" time="0"></testcase>
 		<testcase classname="policies/helpers/runner" name="test_runner_helper/project_medium" time="0"></testcase>
 		<testcase classname="policies/helpers/runner" name="test_runner_helper/project_small" time="0"></testcase>
 	</testsuite>
-	<testsuite tests="0" failures="0" time="0" name="policies/helpers/utils" timestamp="">
+	<testsuite tests="0" failures="0" time="0" name="policies/helpers/utils" timestamp="2024-03-04T10:50:05Z">
 		<properties>
 			<property name="skipped" value="no tests"></property>
 		</properties>
 	</testsuite>
-	<testsuite tests="1" failures="0" time="0" name="policies/multifile" timestamp="">
+	<testsuite tests="1" failures="0" time="0" name="policies/multifile" timestamp="2024-03-04T10:50:05Z">
 		<properties></properties>
 		<testcase classname="policies/multifile" name="test_multifile_policy" time="0"></testcase>
 	</testsuite>
-	<testsuite tests="0" failures="0" time="0" name="policies/multifile/sub0" timestamp="">
+	<testsuite tests="0" failures="0" time="0" name="policies/multifile/sub0" timestamp="2024-03-04T10:50:05Z">
 		<properties>
 			<property name="skipped" value="no tests"></property>
 		</properties>
 	</testsuite>
-	<testsuite tests="0" failures="0" time="0" name="policies/multifile/sub1" timestamp="">
+	<testsuite tests="0" failures="0" time="0" name="policies/multifile/sub1" timestamp="2024-03-04T10:50:05Z">
 		<properties>
 			<property name="skipped" value="no tests"></property>
 		</properties>
 	</testsuite>
-	<testsuite tests="0" failures="0" time="0" name="policies/multifile/sub1/sub1_0" timestamp="">
+	<testsuite tests="0" failures="0" time="0" name="policies/multifile/sub1/sub1_0" timestamp="2024-03-04T10:50:05Z">
 		<properties>
 			<property name="skipped" value="no tests"></property>
 		</properties>

--- a/cpa/tester/result.go
+++ b/cpa/tester/result.go
@@ -17,6 +17,25 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+var (
+	clock Clock = StandardClock{}
+)
+
+type Clock interface {
+	Now() time.Time
+}
+
+type StandardClock struct{}
+
+func (StandardClock) Now() time.Time { return time.Now() }
+
+type MockedClock struct{}
+
+func (MockedClock) Now() time.Time {
+	t, _ := time.Parse(time.RFC3339, "2024-03-04T10:50:05Z")
+	return t
+}
+
 type Result struct {
 	Group  string
 	Name   string
@@ -183,6 +202,7 @@ func (rh JUnitResultHandler) HandleResults(c <-chan Result) bool {
 			return
 		}
 		currentSuite.Time = fmt.Sprintf("%.3f", currentSuiteTime.Seconds())
+		currentSuite.Timestamp = clock.Now().Format(time.RFC3339)
 		currentSuiteTime = 0
 		root.Suites = append(root.Suites, currentSuite)
 	}

--- a/cpa/tester/runner_test.go
+++ b/cpa/tester/runner_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"regexp"
 	"testing"
+	"time"
 
 	_ "embed"
 
@@ -101,10 +102,6 @@ func TestRunnerResults(t *testing.T) {
 	})
 
 	t.Run("xml", func(t *testing.T) {
-		oldClock := clock
-		defer func() { clock = oldClock }()
-		clock = MockedClock{}
-
 		options := RunnerOptions{
 			Path: "./policies/...",
 			Include: func() *regexp.Regexp {
@@ -122,7 +119,10 @@ func TestRunnerResults(t *testing.T) {
 		buf := new(bytes.Buffer)
 		opts := ResultHandlerOptions{Dst: buf}
 
-		MakeJUnitResultHandler(opts).HandleResults(runner.Run())
+		MakeJUnitResultHandlerWithGetTime(opts, func() time.Time {
+			t, _ := time.Parse(time.RFC3339, "2024-03-04T10:50:05Z")
+			return t
+		}).HandleResults(runner.Run())
 
 		suites := junit.JUnitTestSuites{}
 		require.NoError(t, xml.Unmarshal(buf.Bytes(), &suites))

--- a/cpa/tester/runner_test.go
+++ b/cpa/tester/runner_test.go
@@ -101,6 +101,10 @@ func TestRunnerResults(t *testing.T) {
 	})
 
 	t.Run("xml", func(t *testing.T) {
+		oldClock := clock
+		defer func() { clock = oldClock }()
+		clock = MockedClock{}
+
 		options := RunnerOptions{
 			Path: "./policies/...",
 			Include: func() *regexp.Regexp {


### PR DESCRIPTION
## Rationale

This change aims fixes the [CLI issue #1048](https://github.com/CircleCI-Public/circleci-cli/issues/1048): the `timestamp` field of the JUnit test result 

## Considerations

In order to make tests predictable, an interface `Clock` has been added to mock `time.Now()` in the tests.

## Changes

- In `JUnitResultHandler.HandleResults`, made sure every test suite filled its `Timestamp` field with `Clock.Now()` which, in non-test situation, equals `time.Now()`.