### PR TITLE
Fix config policy restriction

### DIFF
--- a/internal/helpers/rego/config/contexts.rego
+++ b/internal/helpers/rego/config/contexts.rego
@@ -41,7 +41,7 @@ contexts_reserved_by_project_ids(project_id, context_list) = {reason |
 }
 
 contexts_reserved_by_branches(branch_list, context_list) = {reason |
-	some wf_name, workflow in input._compiled_.workflows
+	some wf_name, workflow in input.workflows
 	some job_name, job_info in workflow.jobs[_]
 
 	protected_contexts := utils.to_set(context_list) & utils.to_set(job_info.context)
@@ -55,7 +55,7 @@ contexts_reserved_by_branches(branch_list, context_list) = {reason |
 		[wf_name, job_name, concat(", ", protected_contexts), concat(", ", invalid_branches)],
 	)
 } | {reason |
-	some wf_name, workflow in input._compiled_.workflows
+	some wf_name, workflow in input.workflows
 	some job_name, job_info in workflow.jobs[_]
 
 	protected_contexts := utils.to_set(context_list) & utils.to_set(job_info.context)


### PR DESCRIPTION
## Rationale

The compiled workflow does not contain the necessary branch information for the policy to take a decision.

The existing `input._compiled_.workflows` would always show filters as an empty map {}. `input.workflows` contains all the information necessary to make the decision.